### PR TITLE
Revert "Lambda のアーキテクチャを x86_64 から arm64 に変更"

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -3,14 +3,12 @@ service: melt-api
 provider:
   name: aws
   runtime: go1.x
-  memorySize: 512
   stage: ${opt:stage, self:custom.defaultStage}
   region: ap-northeast-1
   logRetentionInDays: 30
   timeout: 20
   versionFunctions: false
   lambdaHashingVersion: 20201221
-  architecture: arm64
   environment:
     KEY_TABLE_NAME: ${self:custom.environment.${self:provider.stage}.aws.dynamodb.api_keys.table_name}
   iamRoleStatements:


### PR DESCRIPTION
Reverts qazsato/melt-api#28

go は arm にサポートしていなかったため戻す。
```
Resource handler returned message: "Runtime go1.x does not support the following architectures [arm64]. Please select different architectures from [x86_64] or select a different runtime. (Service: Lambda, Status Code: 400, Request ID: e3d25e6f-85a5-4a7b-a849-be26c346221b)" (RequestToken: f16451ad-0f71-fd71-ff0c-ac707a48dd41, HandlerErrorCode: InvalidRequest)
```